### PR TITLE
suggested fix for side bar not closing

### DIFF
--- a/client/src/components/card/mainCard.js
+++ b/client/src/components/card/mainCard.js
@@ -52,6 +52,7 @@ return (
         style={{ fontSize: 50 }}/>
     <PantryModal
         isOpen={props.isOpen}
+        close={props.close}
         >
     </PantryModal>
     </Paper>

--- a/client/src/components/card/sideBar.js
+++ b/client/src/components/card/sideBar.js
@@ -40,9 +40,13 @@ const SideBar =(props) => {
   
 
   const handleOpen = () => {
-    setIsOpen((true));
+    console.log('hit handleOpen')
+    if (!isOpen) {
+      setIsOpen((true));
+    }
   };
   const handleClose = () => {
+    console.log('hit close')
     setIsOpen((false));
   };
 
@@ -54,6 +58,8 @@ const SideBar =(props) => {
   const handleDrawerClose = () => {
     setOpen(false);
   };
+
+  console.log('isOpen', isOpen)
 
 
   return (

--- a/client/src/components/pantry/pantryModal.js
+++ b/client/src/components/pantry/pantryModal.js
@@ -62,7 +62,7 @@ class PantryModal extends Component {
             <>
     <ReactModal
         isOpen={this.props.isOpen}
-        close={this.props.close}
+        onRequestClose={this.props.close}
         className="modal__explore overlay"
         appElement={document.getElementById('portal')}
 
@@ -84,7 +84,7 @@ class PantryModal extends Component {
         />
         </div>
         <button>Submit</button>
-        <button onClick={() => this.props.close}>Close</button>
+        <button onClick={this.props.close}>Close</button>
     </form>
     <div className="card-body">
         {this.state.pantry.map(item =>{


### PR DESCRIPTION
A few things when looking at the code:

1. the `close` prop was not being passed to `PantryModal`
2. the correct prop for react-modal to self handle closing (when clicking outside the modal area) is `onRequestClose`
3. because of the way `PantryModal` is nested inside the `Paper` component, when clicking the `Close` button the `handleOpen` function inside of  `SideBar` is getting called (this has been wrapped in logic to check the state before firing, as a stop gap).
4.  The `onClick` function for the button `Close` was not being executed
